### PR TITLE
Adjusted how the demand order list is generated

### DIFF
--- a/Visual.py
+++ b/Visual.py
@@ -346,12 +346,12 @@ class VisualManager():
 
         self.demandorderlist.clear()
    
-        process_df = pd.read_csv("ProcessData.csv")
-        demagrr = process_df.groupby(["DemandID","Product","NrItems"], dropna=True)[['OperationName']].agg(lambda x:list(x)).reset_index()
-
-        for i,r in demagrr.iterrows():
-            self.demandorderlist[len(self.demandorderlist)] = r["DemandID"]
-
+        self.demandorderlist = dict(
+           enumerate(
+              self.getController().getWorkManager().getProductionOrders().keys()
+           )
+        )
+      
         self.getFurtherText().options = [self.getController().getWorkManager().getProductionOrders()[x].getFinalProduct().getPN() for x in self.demandorderlist.values()]
         return 
 #############################################################################################################################################    


### PR DESCRIPTION
Adjusted how the demand order list is generated so that all orders are visible in the results section, rather than just those contained in `processData.csv`. This change prevents an error that occurred when the results selection field was being set up.